### PR TITLE
docs: add 1.21.0 as a note

### DIFF
--- a/users/development-status.md
+++ b/users/development-status.md
@@ -11,6 +11,7 @@ last thing we want is to give up on making features perfect for you just so it c
 |-----------------|------------------------|
 | 1.21.2+         | Waiting on 1.21.1 Port |
 | 1.21.1          | Continued Support      |
+| 1.21.0          | Skipped                |
 | 1.20.2 - 1.20.6 | Skipped                |
 | 1.20.1          | Continued Support      |
 | 1.19.4          | Skipped                |


### PR DESCRIPTION
To avoid confusion for those unfamiliar with the history of Minecraft versions, added the 1.21.0 version as skipped.