### PR TITLE
Move gradle.properties to its own codeblock

### DIFF
--- a/developers/depend-on-create/forge-1.20.1.md
+++ b/developers/depend-on-create/forge-1.20.1.md
@@ -82,15 +82,16 @@ dependencies {
 }
 ```
 
-```properties-vue [gradle.properties]
+:::
+
+And in your `gradle.properties` file:
+```properties-vue
 minecraft_version = {{ $frontmatter.minecraft_version }}
 create_version = {{ $frontmatter.create_version }}
 ponder_version = {{ $frontmatter.ponder_version }}
 flywheel_version = {{ $frontmatter.flywheel_version }}
 registrate_version = {{ $frontmatter.registrate_version }}
 ```
-
-:::
 
 #### Mixin Refmap Remapping [FG]
 

--- a/developers/depend-on-create/neoforge-1.21.1.md
+++ b/developers/depend-on-create/neoforge-1.21.1.md
@@ -43,7 +43,9 @@ dependencies {
     implementation("com.tterrag.registrate:Registrate:${property("registrate_version")}")
 }
 ```
+:::
 
+And in your `gradle.properties` file:
 ```properties-vue [gradle.properties]
 minecraft_version = {{ $frontmatter.minecraft_version }}
 create_version = {{ $frontmatter.create_version }}
@@ -51,8 +53,6 @@ ponder_version = {{ $frontmatter.ponder_version }}
 flywheel_version = {{ $frontmatter.flywheel_version }}
 registrate_version = {{ $frontmatter.registrate_version }}
 ```
-
-:::
 
 ### Production Environment Dependency
 


### PR DESCRIPTION
Currently its stuck in with the build.gradle variants, which doesn't make sense (you need only one of the build.gradles but always need gradle.properties) and is confusing for new devs.