### PR TITLE
Add missing extra return value for signal strate change event

### DIFF
--- a/src/users/cc-tweaked-integration/train/train-signal.md
+++ b/src/users/cc-tweaked-integration/train/train-signal.md
@@ -70,5 +70,15 @@ Triggers whenever the signal changes.
 
 **Returns**
 
+- `string` Position of the signal that triggered this event, relative to the computer.
 - `string` Name of the signal it switched to, either "RED", "GREEN" or "YELLOW" (Only on CROSS_SIGNAL types).
 
+**Example**
+
+Print what signal has changed to what state in the terminal.
+```lua
+while true do
+    local event, side, status = os.pullEvent("train_signal_state_change")
+    print("Signal on side", side, "changed to", status)
+end
+```


### PR DESCRIPTION
The info for the `train_signal_state_change` event is wrong.  
It only mentions the signal state as a return value, when in reality it also returns the position of the signal, relative to the computer (i.e. top).

This PR corrects this, while also adding an example code snippet to help people understand it a bit better.

Note that given this oversight, it might be possible that other events may also have this argument missing.
I haven't tested those, as I don't actually use them, nor have the time to setup a test environment to test the events, so someone should take the time to investigate.