### PR TITLE
Update train-station.md

### DIFF
--- a/src/users/cc-tweaked-integration/train/train-station.md
+++ b/src/users/cc-tweaked-integration/train/train-station.md
@@ -301,6 +301,7 @@ Imminent is defined as being within 30 blocks of the station.
 
 **Returns**
 
+- `string` Name of station.
 - `string` Name of train.
 
 ---
@@ -311,6 +312,7 @@ Triggers whenever a train arrives at the station.
 
 **Returns**
 
+- `string` Name of station.
 - `string` Name of train.
 
 ---
@@ -321,4 +323,5 @@ Triggers whenever a train departs from the station.
 
 **Returns**
 
+- `string` Name of station.
 - `string` Name of train.


### PR DESCRIPTION
Train events were missing a return parameter- os.pullevent(<<train event>>) returns event, station name, train name previous wiki stated that they only returned the train name