### PR TITLE
Update link to Create Fabric addon template

### DIFF
--- a/.vitepress/sidebars/developers.ts
+++ b/.vitepress/sidebars/developers.ts
@@ -30,7 +30,7 @@ export default {
             },
             {
               text: "Fabric",
-              link: "https://github.com/Fabricators-of-Create/create-fabric-addon-template",
+              link: "https://github.com/snackbag/create-fabric-addon-template",
             },
             {
               text: "Multiloader",


### PR DESCRIPTION
Since the official Create Fabric addon template was archived, there was no longer any prominent template. I have created one myself with the motivation to keep it updated. This PR replaces the old addon link with the new one.

The reason I believe my template is better, is because I have set up notifications when one of the dependencies updates, resulting in swift update times.